### PR TITLE
Move poll function to a local var, should fix bugs in IE<9 when minified 

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -132,7 +132,7 @@ var docElement            = doc.documentElement,
     if ( ! oldObj.e && ( isWebkit || isGecko ) ) {
       // A self executing function with a sTimeout poll to call itself
       // again until the css file is added successfully
-      ( function poll ( link ) {
+      var poll = function ( link ) {
         sTimeout( function () {
           // Don't run again if we're already done
           if ( ! done ) {
@@ -167,7 +167,8 @@ var docElement            = doc.documentElement,
             }
           }
         }, 0 );
-      } )( link );
+      };
+      poll( link );
 
     }
     // Onload handler for IE and Opera


### PR DESCRIPTION
Move poll function to a local var, should fix bugs in IE<9 when minified with uglifyjs, due to
https://github.com/mishoo/UglifyJS/issues/161

Should also fix
https://github.com/Modernizr/Modernizr/issues/308
