### PR TITLE
I think this would be better to validate a string because: 

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -42,7 +42,7 @@ var docElement            = doc.documentElement,
       return Object(obj) === obj;
     },
     isString              = function ( s ) {
-      return typeof s == 'string';
+      return s+'' == s;
     },
     isFunction            = function ( fn ) {
       return toString.call( fn ) == '[object Function]';


### PR DESCRIPTION
var a = "I am a string!";
alert(typeof a); // Will output "string"
var b = new String("I am also a string!");
alert(typeof b); // Will output "object"
:)
