### PR TITLE
Support of parametrized prefixes + resourceObj.timeout field

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -366,12 +366,13 @@ var docElement            = doc.documentElement,
         prefixes : parts
       },
       mFunc,
-      j;
+      j,
+      prefix_parts;
 
       // loop through prefixes
       // if there are none, this automatically gets skipped
       for ( j = 0; j < pLen; j++ ) {
-        var prefix_parts = parts[ j ].split( '=' );
+        prefix_parts = parts[ j ].split( '=' );
         mFunc = prefixes[ prefix_parts.shift() ];
         if ( mFunc ) {
           res = mFunc( res, prefix_parts );


### PR DESCRIPTION
Hi!
And sorry for not so good English :)

In the last few days I tried to incorporate yepnope on my site... Little backlog.
Some of our users complaining that jQuery from Google CDN loading very long, maybe forever.
But CDN is so good, everyone should use it, so I wanted to try to load jQuery from GCDN with rather small timeout, then fallback to local jQuery, then load other scripts.

And I tried and made errors and been stupid and poked you (both Alex and Ralph) on Twitter and finally wrote this: http://jsfiddle.net/kkD3W/1/

Testing it, I noticed that BIG.js sometimes don't get executed. Soon I nailed problem to that it's happens when BIG.js not in cache. And poked you couple of times again, sorry :)

Today I finally discovered that in my case all four files starting to load simultaneously, with timeout set before call to yepnope. BIG.js sometimes doesn't loaded in time and get aborted.

Soo, of course I could fix it that way: http://jsfiddle.net/bJTbf/1/
But it's hard to call asynchronous then.

Aand then I decided that it'll be cool to have another prefix, 'timeout' and it should accept parameter, yay!
Like, 'timeout=200!some_url.js'. Of course, it required to introduce new resourceObj field, named, err, 'timeout' :)
Here it is.

It can be used like this: http://jsfiddle.net/jjZMZ/

I think it quite general support of parametrized prefixes; one can write 'mylittleprefix=JSON!url.js' and be totally happy.

Hope its good candidate for merge.
Thanks for excellent work!
