### PR TITLE
Support LESS CSS ( loading .less resources )

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -123,7 +123,7 @@ var docElement            = doc.documentElement,
     // Add attributes
     link.href = oldObj.s;
     link.rel  = 'stylesheet';
-    link.type = 'text/css';
+    link.type = (/\.less$/.test( oldObj.s )) ? 'text/less' : 'text/css';
 
     // Poll for changes in webkit and gecko
     if ( ! oldObj.e && ( isWebkit || isGecko ) ) {
@@ -405,7 +405,7 @@ var docElement            = doc.documentElement,
       }
       else {
 
-        chain.load( resource.url, ( ( resource.forceCSS || ( ! resource.forceJS && /css$/.test( resource.url ) ) ) ) ? 'c' : undef, resource.noexec );
+        chain.load( resource.url, ( ( resource.forceCSS || ( ! resource.forceJS && /\.(le?|c)ss$/.test( resource.url ) ) ) ) ? 'c' : undef, resource.noexec );
 
         // If we have a callback, we'll start the chain over
         if ( isFunction( callback ) || isFunction( autoCallback ) ) {


### PR DESCRIPTION
Enable `.less` files to be loaded as "CSS" with `type="text/less"`.

Does not require the use of the `css!` prefix plugin to forceCSS processing.

**Usage:**

`yepnope('styles.less');`

**Result:**

`<link href="styles.less" rel="stylesheet" type="text/less">`

**Taking it further:**

You could explore supporting user controlled "rel" and "type" attributes for both "script" and "link" elements. This would make yepnope a more robust "resource loader"... e.g. another use case would be coffee-script's `<script type="text/coffeescript">` (http://jashkenas.github.com/coffee-script/#scripts)... please feel free to move this idea out into another issue/feature request ticket.
