### PR TITLE
update to css.php to allow query strings

### DIFF
--- a/tests/css/css.php
+++ b/tests/css/css.php
@@ -8,5 +8,6 @@ if (sizeof($matches) > 1) {
   sleep($matches[1]);
 }
 
-$num = basename($_SERVER['REQUEST_URI'], '.css');
+$parts = explode( "?", $_SERVER['REQUEST_URI'] );
+$num = basename($parts[0], '.css');
 echo '#item_' . str_replace(',','',$num) . ' { color: rgb(' . $num . '); }';


### PR DESCRIPTION
The unit tests failed on css query strings due to an issue in css.php (the file we use to emulate css loading programmatically), not an issue with yepnope.js as a library. This fixes that issue.
