### PR TITLE
Support for specifying scope in callbacks. First attempt.

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -14,7 +14,6 @@
 // Please minify before use.
 // Also available as Modernizr.load via the Modernizr Project
 //
-//Test Commit
 ( function ( window, doc, undef ) {
 
 var docElement            = doc.documentElement,
@@ -415,8 +414,8 @@ var docElement            = doc.documentElement,
             // Hijack yepnope and restart index counter
             getYepnope();
             // Call our callbacks with this set of data
-            callback && callback( resource.origUrl, testResult, index );
-            autoCallback && autoCallback( resource.origUrl, testResult, index );
+            callback && callback.call(window.yepnope.callbackScope, resource.origUrl, testResult, index );
+            autoCallback && autoCallback.call(window.yepnope.callbackScope, resource.origUrl, testResult, index );
           } );
         }
       }
@@ -428,6 +427,10 @@ var docElement            = doc.documentElement,
             always     = testObject.load || testObject.both,
             callback   = testObject.callback,
             callbackKey;
+  
+        //Store the callbackScope in a naughty way.
+        //I tried to figure out the pass from load > exec stack > callback execution, and now I have a headache.
+        window.yepnope.callbackScope = testObject.callbackScope || this;
 
         // Reusable function for dealing with the different input types
         // NOTE:: relies on closures to keep 'chain' up to date, a bit confusing, but


### PR DESCRIPTION
I really needed a way to control the scope in the yepnope callbacks.
This is a lousy way of doing that, but it works for my needs.
I tried to do it correctly, but your execstack was beyond my abilities to figure out.

Goal for me is to be able to use yepnope like this:

```
myNamespace.emc = function()
{
    this.buildInitialView();
}//Constructor

myNamespace.emc.prototype = {
    tabBar: null

,   buildInitialView: function()
    {
        yepnope({
                test: true
            ,   yep: 'components/myNamespace.slidingTabBar.js'
            ,   callback: function(a, b, c, d) {
                    this.tabBar = new myNamespace.slidingTabBar();
                    this.hello();            
                }
            ,   callbackScope: this
        });//yepnope
    }
,   hello: function()
    {
        console.log('Hello from myNamespace.emc');
    }
}
```
