### PR TITLE
Fixes #88. Reintroduce check for Opera

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -29,8 +29,10 @@ var docElement            = doc.documentElement,
     isGecko               = ( "MozAppearance" in docElement.style ),
     isGeckoLTE18          = isGecko && !! doc.createRange().compareNode,
     insBeforeObj          = isGeckoLTE18 ? docElement : firstScript.parentNode,
-    isIE                  = !! doc.attachEvent,
-    strJsElem             = isGecko ? "object" : isIE ? "script" : "img",
+    // Thanks to @jdalton for showing us this opera detection (by way of @kangax) (and probably @miketaylr too, or whatever...)
+    isOpera               = window.opera && toString.call( window.opera ) == "[object Opera]",
+    isIE                  = !! doc.attachEvent && !isOpera,
+    strJsElem             = isGecko ? "object" : isIE  ? "script" : "img",
     strCssElem            = isIE ? "script" : strJsElem,
     isArray               = Array.isArray || function ( obj ) {
       return toString.call( obj ) == "[object Array]";


### PR DESCRIPTION
This patch reintroduces the check for Opera. So an `<img>` is used for preloading. This will make sites using yepnope responsive in Opera again.
