### PR TITLE
updates to CSS plugin

### DIFF
--- a/plugins/yepnope.css.js
+++ b/plugins/yepnope.css.js
@@ -11,7 +11,7 @@
             setTimeout( cb, 0 );
           }
         },
-        id = "yn" + new Date,
+        id = "yn" + +new Date,
         ref, done, i;
 
     cb = internal ? yepnope.executeStack : ( cb || function(){} );


### PR DESCRIPTION
A project of mine uses Media Queries and CSS and we needed to use the CSS plugin to delay execution otherwise our JS would execute without proper sizing rules being applied.

I found the plugin was not working properly all of the time (about half the time my JS would execute before the CSS was available). With a bit of debugging I found that `document.styleSheets` sometimes did not contain the newly injected link element. When this is the case, the original the `poll` function is only executed once and `onload` is always called. Basically, the `for` loop does not find a stylesheet with `id` and exception is never created.

I modified the code to handle this case and it seems to work every time now within my Project (when the media queries aren't available dynamically created elements aren't sized properly and it's very easy to know the load order was incorrect) 

I'm not sure how I should test this. Any ideas?
