### PR TITLE
Read firstScript when it is removed from DOM

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -46,7 +46,7 @@ var docElement            = doc.documentElement,
       return toString.call( fn ) == "[object Function]";
     },
     readFirstScript       = function() {
-        if (!firstScript || firstScript.parentNode) {
+        if (!firstScript || !firstScript.parentNode) {
             firstScript = doc.getElementsByTagName( "script" )[ 0 ];
         }
     },


### PR DESCRIPTION
This commit fixes a weird bug that happens when the firstScript is removed from the DOM. This was happening to us if we called jQuery.getJSON() with JSONP.
