### PR TITLE
pathfilter bugfix

### DIFF
--- a/filters/yepnope.pathfilter.js
+++ b/filters/yepnope.pathfilter.js
@@ -1,13 +1,13 @@
 /**
  * YepNope Path Filter
- * 
+ *
  * Usage:
  *   yepnope.paths = {
- *	   'google': '//ajax.googleapis.com/ajax',
- *	   'my-cdn': '//cdn.myawesomesite.com'
+ *     'google': '//ajax.googleapis.com/ajax',
+ *     'my-cdn': '//cdn.myawesomesite.com'
  *   };
  *   yepnope({
- *	   load: ['google/jquery/1.7.2/jquery.min.js', 'google/jqueryui/1.8.18/jquery-ui.min.js', 'my-cdn/style.css', '/non/path/directory/file.js']
+ *     load: ['google/jquery/1.7.2/jquery.min.js', 'google/jqueryui/1.8.18/jquery-ui.min.js', 'my-cdn/style.css', '/non/path/directory/file.js']
  *   });
  *
  * Official Yepnope Plugin
@@ -22,8 +22,11 @@
       yn.addFilter(function (resource) {
         // check each url for path
         for (path in yn.paths) {
-          resource.url = resource.url.replace(new RegExp('^' + path), yn.paths[path]);
-          return resource;
+          var pathRegExp = new RegExp('^'  + path);
+          if (resource.url.match(pathRegExp)) {
+            resource.url = resource.url.replace(pathRegExp, yn.paths[path]);
+            return resource;
+          }
         }
         // carry on my wayward, son
         return resource;


### PR DESCRIPTION
Fixes 404 errors and slowness with the yepnope.js path filter when there is more than one path prefix in yepnope.paths.
