### PR TITLE
Fixed issue #95 with older webkit browsers and cached assets not loading properly

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -31,8 +31,10 @@ var docElement            = doc.documentElement,
     // Thanks to @jdalton for showing us this opera detection (by way of @kangax) (and probably @miketaylr too, or whatever...)
     isOpera               = window.opera && toString.call( window.opera ) == "[object Opera]",
     isIE                  = !! doc.attachEvent && !isOpera,
-    strJsElem             = isGecko ? "object" : isIE  ? "script" : "img",
-    strCssElem            = isIE ? "script" : strJsElem,
+    // isOlderWebkit fix for #95 - https://github.com/SlexAxton/yepnope.js/issues/95
+    isOlderWebkit		  = ( 'webkitAppearance' in docElement.style ) && !( 'async' in doc.createElement('script') ),
+    strJsElem             = isGecko ? "object" : (isIE || isOlderWebkit)  ? "script" : "img",
+    strCssElem            = isIE ? "script" : (isOlderWebkit) ? "img" : strJsElem,
     isArray               = Array.isArray || function ( obj ) {
       return toString.call( obj ) == "[object Array]";
     },


### PR DESCRIPTION
I added a check for older webkit browsers...  which determines the dom element used to load the resources.  This is working on my older Android 2.3 device while newer webkit browsers remain unchanged.
