### PR TITLE
Insert before link element rather than base

### DIFF
--- a/plugins/yepnope.css.js
+++ b/plugins/yepnope.css.js
@@ -29,7 +29,7 @@
 
 
     if ( ! err ) {
-      ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0];
+      ref = document.getElementsByTagName('link')[0] || document.getElementsByTagName('script')[0];
       ref.parentNode.insertBefore( link, ref );
       link.onload = onload;
 


### PR DESCRIPTION
Had an issue in an SPA where link elements would get lost and styles not applied since it was inserting them inside dynamic regions, due to script tags used for templating. This fixed it.
