### PR TITLE
Add the reexecute prefix

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -61,7 +61,12 @@ var docElement            = doc.documentElement,
           resourceObj['timeout'] = prefix_parts[ 0 ];
         }
         return resourceObj;
+      },
+      reexecute : function( resourceObj, prefix_parts ) {
+        resourceObj['reexecute'] = true;
+        return resourceObj;
       }
+    },
     },
     handler,
     yepnope;


### PR DESCRIPTION
IMHO, and following #138, a `reexecute` prefix would be a nice way to trigger the reexecution. Right now the code for reexecution is there but you have to define your own prefix in order to use it, little bit weird.
