### PR TITLE
fix wrong calculation of "strJsElem"

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -279,6 +279,11 @@ var docElement            = doc.documentElement,
 
     // We'll do 'j' for js and 'c' for css, yay for unreadable minification tactics
     type = type || "j";
+
+    if(type == "j") {
+      strJsElem = "script";
+    }
+
     if ( isString( resource ) ) {
       // if the resource passed in here is a string, preload the file
       preloadFile( type == "c" ? strCssElem : strJsElem, resource, type, this['i']++, dontExec, attrObj, timeout );


### PR DESCRIPTION
Hi folks,

I recongized this bug on loading jquery.js once from google and than as a condition from the hard-drive. Any time jquery.js was loaded twice times - first as a IMG type and after again as type JS. This short code snippet was the fix.

Best regards from Germany,
Gjero
