### PR TITLE
Fixed issue when function poll is called infinitely

### DIFF
--- a/plugins/yepnope.css.js
+++ b/plugins/yepnope.css.js
@@ -35,6 +35,7 @@
 
       function poll() {
         try {
+            if (done) return;
             var sheets = document.styleSheets;
             for(var j=0, k=sheets.length; j<k; j++) {
                 if(sheets[j].ownerNode.id == id) {


### PR DESCRIPTION
yepnope.css.js polls for new CSS styles and executes "onload" callback when they are loaded. If <link> element supports "onload" event then it happens faster but might lead to infinite polling.
