### PR TITLE
Improve reliability of readyState on IE (possible fix for #154, #195)

### DIFF
--- a/yepnope.js
+++ b/yepnope.js
@@ -69,7 +69,7 @@ var docElement            = doc.documentElement,
   /* Loader helper functions */
   function isFileReady ( readyState ) {
     // Check to see if any of the ways a file can be ready are available as properties on the file's element
-    return ( ! readyState || readyState == "loaded" || readyState == "complete" || readyState == "uninitialized" );
+    return ( ! readyState || readyState == "loaded" || readyState == "complete" );
   }
 
 
@@ -95,7 +95,13 @@ var docElement            = doc.documentElement,
     script.onreadystatechange = script.onload = function () {
 
       if ( ! done && isFileReady( script.readyState ) ) {
-
+		
+		// Inject script into to document (if NOT using onload)
+		if(!err && script.readyState){
+			readFirstScript();
+			firstScript.parentNode.insertBefore( script, firstScript );
+		}
+		
         // Set done to prevent this function from being called twice.
         done = 1;
         cb();
@@ -114,11 +120,17 @@ var docElement            = doc.documentElement,
       }
     }, timeout );
 
-    // Inject script into to document
+    // Inject script into to document (if using onload)
     // or immediately callback if we know there
     // was previously a timeout error
-    readFirstScript();
-    err ? script.onload() : firstScript.parentNode.insertBefore( script, firstScript );
+	if(!err){
+		if(!script.readyState){
+			readFirstScript();
+			firstScript.parentNode.insertBefore( script, firstScript );
+		}
+	}else{
+		script.onload()
+	}
   }
 
   // Takes a preloaded css obj (changes in different browsers) and injects it into the head


### PR DESCRIPTION
This is an attempt on fixing an unusual issue reported in details here - http://stackoverflow.com/questions/19781753/modernizr-load-callback-executing-before-loaded-script

The issue was very hard to isolate and reproduce, but I believe the following is true on IE8 and IE9:
When a script node is appended to the DOM and is not fully loaded, it will execute after loading, not necessarilly before the callback. When a fully loaded script is appended to the DOM, it is parsed and executed immediately, securely before the callback.

The changes on this commit resolved my problems on IE8 and IE9, and didn't cause any issue as far as I could see on latest (11/11/2013) Chrome, Firefox and Opera.
